### PR TITLE
Remove config dependency from enqueue classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 *No documentation available about unreleased changes as of yet.*
 
+### Removed
+- Removed `Config` dependency from enqueue classes
+
+### Changed
+- Updated `eightshift-libs` to 2.2.0
+
 ## [4.1.0] - 2020-03-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,6 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 ### Removed
 - Removed `Config` dependency from enqueue classes
 
-### Changed
-- Updated `eightshift-libs` to 2.2.0
-
 ## [4.1.0] - 2020-03-05
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   },
   "require": {
     "php": ">=7.1",
-    "infinum/eightshift-libs": "^2.1.1"
+    "infinum/eightshift-libs": "^2.2.0"
   },
   "autoload": {
     "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   },
   "require": {
     "php": ">=7.1",
-    "infinum/eightshift-libs": "^2.2.0"
+    "infinum/eightshift-libs": "^2.1.1"
   },
   "autoload": {
     "classmap": [

--- a/src/class-main.php
+++ b/src/class-main.php
@@ -59,9 +59,9 @@ class Main extends Lib_Core {
       Lib_I18n\I18n::class => [ Config::class ],
 
       // Enqueue.
-      Lib_Enqueue\Enqueue_Admin::class => [ Config::class, Lib_Manifest\Manifest::class ],
-      Lib_Enqueue\Enqueue_Theme::class => [ Config::class, Lib_Manifest\Manifest::class ],
-      Lib_Enqueue\Enqueue_Blocks::class => [ Config::class, Lib_Manifest\Manifest::class ],
+      Lib_Enqueue\Enqueue_Admin::class => [ Lib_Manifest\Manifest::class ],
+      Lib_Enqueue\Enqueue_Theme::class => [ Lib_Manifest\Manifest::class ],
+      Lib_Enqueue\Enqueue_Blocks::class => [ Lib_Manifest\Manifest::class ],
 
       // Login.
       Lib_Login\Login::class,


### PR DESCRIPTION
Also updated libs to the version which has this change with the config.

This PR addresses #201 issue.

It's dependent on libs PR: https://github.com/infinum/eightshift-libs/pull/49 and a new libs release.

It's a minor breaking change. We could emphasize this in the release notes.