### PR TITLE
add selector class to footer

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -17,6 +17,7 @@ echo wp_kses_post(
 	Components::render(
 		'layout-three-columns',
 		[
+			'selectorClass' => 'footer',
 			'layoutLeft' => Components::render(
 				'copyright',
 				[


### PR DESCRIPTION
Because `selectorClass` was missing in `footer.php` styles from `components/footer/footer-style.scss` weren't being applied at all.