### PR TITLE
Improve header / footer accessibility

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -16,6 +16,7 @@ use EightshiftBoilerplateVendor\EightshiftLibs\Helpers\Components;
 echo Components::render( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	'layout-three-columns',
 	[
+		'layoutThreeColumnsAriaRole' => 'contentinfo',
 		'additionalClass' => 'footer',
 		'layoutThreeColumnsLeft' => Components::render(
 			'copyright',

--- a/header.php
+++ b/header.php
@@ -32,6 +32,8 @@ use EightshiftBoilerplate\Manifest\Manifest;
 echo Components::render( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	'layout-three-columns',
 	[
+		'layoutThreeColumnsAriaRole' => 'navigation',
+		'layoutThreeColumnsHtmlTag' => 'nav',
 		'additionalClass' => 'header',
 		'layoutThreeColumnsLeft' => Components::render(
 			'logo',

--- a/header.php
+++ b/header.php
@@ -72,9 +72,6 @@ echo Components::render( // phpcs:ignore WordPress.Security.EscapeOutput.OutputN
 		),
 	]
 );
-
-// Page Overlay Component.
-echo Components::render('page-overlay'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 ?>
 
 <main class="main-content">

--- a/header.php
+++ b/header.php
@@ -61,8 +61,6 @@ echo Components::render( // phpcs:ignore WordPress.Security.EscapeOutput.OutputN
 	'drawer',
 	[
 		'drawerTrigger' => 'js-hamburger',
-		'drawerOverlay' => 'js-page-overlay',
-		'drawerPosition' => 'right',
 		'drawerMenu' => Components::render(
 			'menu',
 			[


### PR DESCRIPTION
# Description

This PR, along with [the one on infinum/eightshift-frontend-libs](https://github.com/infinum/eightshift-frontend-libs/pull/540), fixes the accessibility issues reported in infinum/eightshift-frontend-libs#534.

* Stops rendering page overlay in header navigation
* Removes `drawerOverlay`, `drawerPosition` attributes from the `drawer` component render call in header
* Adds ARIA roles and suitable semantic tags to `layout-three-column` component render calls in header and footer


