### PR TITLE
Remove ARIA role navigation from nav element

### DIFF
--- a/header.php
+++ b/header.php
@@ -32,7 +32,6 @@ use EightshiftBoilerplate\Manifest\Manifest;
 echo Components::render( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	'layout-three-columns',
 	[
-		'layoutThreeColumnsAriaRole' => 'navigation',
 		'layoutThreeColumnsHtmlTag' => 'nav',
 		'additionalClass' => 'header',
 		'layoutThreeColumnsLeft' => Components::render(


### PR DESCRIPTION
# Description

Removes the navigation role from `<nav>` element in header navigation.

Companion to https://github.com/infinum/eightshift-frontend-libs/pull/593

Relevant issue: https://github.com/infinum/eightshift-frontend-libs/issues/491
