### PR TITLE
REM base transformation

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,18 @@
 const autoprefixer = require('autoprefixer');
+const globalManifest = require('./src/Blocks/manifest.json');
+const transformRemsPlugin = require('./postcss/es-transforms-rems');
 
-module.exports = {
-	plugins: [
-		autoprefixer,
-	],
+module.exports = ({ file }) => {
+	let plugins = [autoprefixer];
+
+	if (globalManifest?.config?.useRemBaseSize && file.endsWith('/application-blocks-editor.scss')) {
+		plugins = [
+			...plugins,
+			transformRemsPlugin,
+		];
+	}
+
+	return {
+		plugins,
+	};
 };

--- a/postcss/es-transforms-rems.js
+++ b/postcss/es-transforms-rems.js
@@ -1,0 +1,9 @@
+const postcss = require('postcss');
+
+module.exports = postcss.plugin('es-transform-rems', () => {
+	return (css) => {
+		css.walkDecls((decl) => {
+			decl.value = decl.value.replace(/([0-9.-]+rem)/g, 'calc($1 * var(--base-font-size, 1))');
+		});
+	};
+});


### PR DESCRIPTION
# Description
- extend postcss functionality with rem base transformation
- add module es-transform-rems

# Linked documentation PR
- soon

# NOTE
This piece of code works for all editor SCSS files.
It goes to preprocessing to change `{value}rem` values to `calc(var(--base-font-size, 1) * {value}rem);`
It will only do it if the `useRemBaseSize` is set in the blocks manifest to ensure compatibility with previous projects.