### PR TITLE
Update .browserslistrc

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,4 +1,3 @@
 defaults
 not IE 11
 not op_mini all
-not op_mob 64


### PR DESCRIPTION
Fixes the BrowserslistError thrown on the `npm start` command. 

Closes #263